### PR TITLE
Add advection example and cleanup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.6'
           - '^1.9.0-0'
           - '^1.10.0-0'
         os:

--- a/examples/advection/LocalPreferences.toml
+++ b/examples/advection/LocalPreferences.toml
@@ -1,0 +1,13 @@
+[CUDA_Runtime_jll]
+# which CUDA runtime to use. in normal cases, this will be auto-detected, but you need to
+# set this preference if you want to precompile CUDA.jl in an envirnonment without CUDA
+#version = "11.8"
+
+# whether to use a local CUDA installation. if CUDA isn't available during precompilation,
+# you will also need to set the "version" preference, matching the local CUDA version.
+#local = "false"
+
+[CUDA]
+# whether to use a nonblocking synchronization mechanism,
+# making it possible to do use cooperative multitasking.
+nonblocking_synchronization = false

--- a/examples/advection/Project.toml
+++ b/examples/advection/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Raven = "cfd3f2ab-0fb0-4d51-9553-03e53d33f144"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"

--- a/examples/advection/semdg_advection_2d.jl
+++ b/examples/advection/semdg_advection_2d.jl
@@ -229,7 +229,7 @@ function rhs!(dq, q, grid, invwJ, DT, cm)
     cell = referencecell(grid)
 
     dRdX, wJ = components(first(volumemetrics(grid)))
-    n, wsJ = components(surfacemetrics(grid)[3])
+    n, wsJ = components(first(surfacemetrics(grid)))
     fm = facemaps(grid)
 
     start!(q, cm)
@@ -255,8 +255,8 @@ function rhs!(dq, q, grid, invwJ, DT, cm)
     rhs_surface_kernel!(backend, (J, C))(
         dq,
         viewwithghosts(q),
-        fm.avmapM,
-        fm.avmapP,
+        fm.vmapM,
+        fm.vmapP,
         n,
         wsJ,
         invwJ,

--- a/examples/advection/semdg_advection_2d.jl
+++ b/examples/advection/semdg_advection_2d.jl
@@ -344,7 +344,7 @@ function run(
     # precompute derivative transpose
     DT = transpose.(derivatives_1d(cell))
 
-    cm = commmanager(eltype(q), comm, nodecommpattern(grid), 0)
+    cm = commmanager(eltype(q), nodecommpattern(grid); comm)
 
     # initial output
     step = 0

--- a/examples/advection/semdg_advection_2d.jl
+++ b/examples/advection/semdg_advection_2d.jl
@@ -1,0 +1,452 @@
+#
+# The Volume and Surface kernels are adapted from libParanumal.
+#
+# @MISC{ChalmersKarakusAustinSwirydowiczWarburton2020,
+#    author = {Chalmers, N. and Karakus, A. and Austin, A. P.
+#       and Swirydowicz, K. and Warburton, T.},
+#    title = {{libParanumal}: a performance portable high-order
+#       finite element library},
+#    year = {2022},
+#    url = {https://github.com/paranumal/libparanumal},
+#    doi = {10.5281/zenodo.4004744},
+#    note = {Release 0.5.0}
+# }
+#
+using Adapt
+using MPI
+using CUDA
+using KernelAbstractions
+using KernelAbstractions.Extras: @unroll
+using LinearAlgebra
+using Printf
+using Raven
+using StaticArrays
+using WriteVTK
+
+# advection velocity
+const v = SVector(1, 1)
+
+# Gaussian initial condition
+function gaussian(x, t)
+    FT = eltype(x)
+    xp = mod1.(x .- v .* t, FT(2π))
+    xc = SVector{2,FT}(π, π)
+    exp(-2norm(xp .- xc)^2)
+end
+
+# sine initial condition
+sineproduct(x, t) = prod(sin.(x .- v .* t))
+
+meshwarp(x) =
+    SVector(x[1] + sin(x[1] / 2) * sin(x[2]), x[2] - sin(x[1]) * sin(x[2] / 2) / 2)
+
+@kernel function rhs_volume_kernel!(
+    dq,
+    q,
+    dRdX,
+    wJ,
+    invwJ,
+    DT,
+    v,
+    ::Val{N},
+    ::Val{C},
+) where {N,C}
+    i, j, c1 = @index(Local, NTuple)
+    _, _, c = @index(Global, NTuple)
+
+    lDT1 = @localmem eltype(q) (N[1], N[1])
+    lDT2 = @localmem eltype(q) (N[2], N[2])
+    lF = @localmem eltype(q) (N..., C)
+    lG = @localmem eltype(q) (N..., C)
+
+    @inbounds begin
+        for sj = 0x0:N[2]:(N[1]-0x1)
+            if j + sj <= N[1] && c1 == 0x1
+                lDT1[i, j+sj] = DT[1][i, j+sj]
+            end
+        end
+
+        for si = 0x0:N[1]:(N[2]-0x1)
+            if i + si <= N[2] && c1 == 0x1
+                lDT2[i+si, j] = DT[2][i+si, j]
+            end
+        end
+
+        qijc = q[i, j, c]
+        dRdXijc = dRdX[i, j, c]
+        wJijc = wJ[i, j, c]
+
+        fluxijc = (qijc * v)
+        vdRdXijc = wJijc * (dRdXijc * fluxijc)
+
+        lF[i, j, c1] = vdRdXijc[1]
+        lG[i, j, c1] = vdRdXijc[2]
+    end
+
+    @synchronize
+
+    @inbounds begin
+        dqijc_update = -zero(eltype(dq))
+        invwJijc = invwJ[i, j, c]
+
+        @unroll for m = 0x1:N[1]
+            dqijc_update += lDT1[i, m] * lF[m, j, c1]
+        end
+
+        @unroll for n = 0x1:N[2]
+            dqijc_update += lDT2[j, n] * lG[i, n, c1]
+        end
+
+        dq[i, j, c] += invwJijc * dqijc_update
+    end
+end
+
+@kernel function rhs_surface_kernel!(
+    dq,
+    q,
+    vmapM,
+    vmapP,
+    n,
+    wsJ,
+    invwJ,
+    ::Val{N},
+    ::Val{C},
+) where {N,C}
+
+    ij, c1 = @index(Local, NTuple)
+    _, c = @index(Global, NTuple)
+
+    lqflux = @localmem eltype(dq) (N..., C)
+
+    @inbounds if ij <= N[1]
+        i = ij
+        @unroll for j = 1:N[2]
+            lqflux[i, j, c1] = -zero(eltype(lqflux))
+        end
+    end
+
+    @synchronize
+
+    @inbounds if ij <= N[2]
+        # Faces with r=-1
+        i = 1
+        j = ij
+        fid = j
+
+        idM = vmapM[fid, c]
+        idP = vmapP[fid, c]
+
+        nf = n[fid, c]
+        wsJf = wsJ[fid, c]
+
+        qM = q[idM]
+        qP = q[idP]
+
+        invwJijc = invwJ[idM]
+
+        fscale = invwJijc * wsJf / 2
+        lqflux[i, j, c1] +=
+            fscale * ((nf ⋅ (v * qM)) + (nf ⋅ (v * qP)) - abs(nf ⋅ v) * (qP - qM))
+
+        # Faces with r=1
+        i = N[1]
+        j = ij
+        fid = N[2] + j
+
+        idM = vmapM[fid, c]
+        idP = vmapP[fid, c]
+
+        nf = n[fid, c]
+        wsJf = wsJ[fid, c]
+
+        qM = q[idM]
+        qP = q[idP]
+
+        invwJijc = invwJ[idM]
+
+        fscale = invwJijc * wsJf / 2
+        lqflux[i, j, c1] +=
+            fscale * ((nf ⋅ (v * qM)) + (nf ⋅ (v * qP)) - abs(nf ⋅ v) * (qP - qM))
+    end
+
+    @synchronize
+
+    @inbounds if ij <= N[1]
+        # Faces with s=-1
+        i = ij
+        j = 1
+        fid = 2N[2] + i
+
+        idM = vmapM[fid, c]
+        idP = vmapP[fid, c]
+
+        nf = n[fid, c]
+        wsJf = wsJ[fid, c]
+
+        qM = q[idM]
+        qP = q[idP]
+
+        invwJijc = invwJ[idM]
+
+        fscale = invwJijc * wsJf / 2
+        lqflux[i, j, c1] +=
+            fscale * ((nf ⋅ (v * qM)) + (nf ⋅ (v * qP)) - abs(nf ⋅ v) * (qP - qM))
+
+        # Faces with s=1
+        i = ij
+        j = N[2]
+        fid = 2N[2] + N[1] + i
+
+        idM = vmapM[fid, c]
+        idP = vmapP[fid, c]
+
+        nf = n[fid, c]
+        wsJf = wsJ[fid, c]
+
+        qM = q[idM]
+        qP = q[idP]
+
+        invwJijc = invwJ[idM]
+
+        fscale = invwJijc * wsJf / 2
+        lqflux[i, j, c1] +=
+            fscale * ((nf ⋅ (v * qM)) + (nf ⋅ (v * qP)) - abs(nf ⋅ v) * (qP - qM))
+    end
+
+    @synchronize
+
+    # RHS update
+    i = ij
+    @inbounds if i <= N[1]
+        @unroll for j = 1:N[2]
+            dq[i, j, c] -= lqflux[i, j, c1]
+        end
+    end
+end
+
+function rhs!(dq, q, grid, invwJ, DT, cm)
+    backend = Raven.get_backend(dq)
+    cell = referencecell(grid)
+
+    dRdX, wJ = components(first(volumemetrics(grid)))
+    n, wsJ = components(surfacemetrics(grid)[3])
+    fm = facemaps(grid)
+
+    Raven.start!(q, cm)
+
+    C = max(512 ÷ prod(size(cell)), 1)
+    rhs_volume_kernel!(backend, (size(cell)..., C))(
+        dq,
+        q,
+        dRdX,
+        wJ,
+        invwJ,
+        DT,
+        v,
+        Val(size(cell)),
+        Val(C);
+        ndrange = size(dq),
+    )
+
+    Raven.finish!(q, cm)
+
+    J = maximum(size(cell))
+    C = max(512 ÷ J, 1)
+    rhs_surface_kernel!(backend, (J, C))(
+        dq,
+        viewwithghosts(q),
+        fm.avmapM,
+        fm.avmapP,
+        n,
+        wsJ,
+        invwJ,
+        Val(size(cell)),
+        Val(C);
+        ndrange = (J, last(size(dq))),
+    )
+
+end
+
+function run(
+    solution,
+    FT,
+    AT,
+    N,
+    K,
+    L;
+    outputvtk = false,
+    vtkdir = "output",
+    comm = MPI.COMM_WORLD,
+)
+    rank = MPI.Comm_rank(comm)
+    cell = LobattoCell{Tuple{(N .+ 1)...},FT,AT}()
+    coordinates = ntuple(_ -> range(FT(0), stop = FT(2π), length = K + 1), 2)
+    periodicity = (true, true)
+    gm = GridManager(cell, brick(coordinates, periodicity); comm = comm, min_level = L)
+    grid = generate(meshwarp, gm)
+
+    timeend = FT(2π)
+
+    # crude dt estimate
+    cfl = 1 // 20
+    dx = Base.step(first(coordinates))
+    dt = cfl * dx / (maximum(N))^2
+
+    numberofsteps = ceil(Int, timeend / dt)
+    dt = timeend / numberofsteps
+
+    RKA = (
+        FT(0),
+        FT(-567301805773 // 1357537059087),
+        FT(-2404267990393 // 2016746695238),
+        FT(-3550918686646 // 2091501179385),
+        FT(-1275806237668 // 842570457699),
+    )
+    RKB = (
+        FT(1432997174477 // 9575080441755),
+        FT(5161836677717 // 13612068292357),
+        FT(1720146321549 // 2090206949498),
+        FT(3134564353537 // 4481467310338),
+        FT(2277821191437 // 14882151754819),
+    )
+
+    if outputvtk
+        rank == 0 && mkpath(vtkdir)
+        pvd = rank == 0 ? paraview_collection("timesteps") : nothing
+    end
+
+    do_output = function (step, time, q)
+        if outputvtk && step % ceil(Int, timeend / 100 / dt) == 0
+            cd(vtkdir) do
+                filename = "step$(lpad(step, 6, '0'))"
+                vtkfile = vtk_grid(filename, grid)
+                P = toequallyspaced(cell)
+                vtkfile["q"] = Adapt.adapt(Array, P * q)
+                vtkfile["CellNumber"] = (1:length(grid)) .+ offset(grid)
+                vtk_save(vtkfile)
+                if rank == 0
+                    pvd[time] = vtkfile
+                end
+            end
+        end
+    end
+
+    # initialize state
+    q = solution.(points(grid), FT(0))
+
+    # storage for RHS
+    dq = similar(q)
+    dq .= 0
+
+    # precompute inverse of weights × Jacobian
+    _, wJ = components(first(volumemetrics(grid)))
+    invwJ = inv.(wJ)
+    # precompute derivative transpose
+    DT = transpose.(derivatives_1d(cell))
+
+    cm = Raven.commmanager(eltype(q), comm, nodecommpattern(grid), 0)
+
+    # initial output
+    step = 0
+    time = FT(0)
+    do_output(step, time, q)
+
+    # time integration
+    for step = 1:numberofsteps
+        if time + dt > timeend
+            dt = timeend - time
+        end
+        for stage in eachindex(RKA, RKB)
+            @. dq *= RKA[stage]
+            rhs!(dq, q, grid, invwJ, DT, cm)
+            @. q += RKB[stage] * dt * dq
+        end
+        time += dt
+        do_output(step, time, q)
+    end
+
+    # final output
+    do_output(numberofsteps, timeend, q)
+    if outputvtk && rank == 0
+        cd(vtkdir) do
+            vtk_save(pvd)
+        end
+    end
+
+    # compute error
+    _, wJ = components(first(volumemetrics(grid)))
+    qexact = solution.(points(grid), timeend)
+    # TODO add sum to GridArray so the following reduction is on the device
+    errf = sqrt(MPI.Allreduce(sum(Adapt.adapt(Array, wJ .* (q .- qexact) .^ 2)), +, comm))
+
+    return errf
+end
+
+let
+    if !MPI.Initialized()
+        MPI.Init(; threadlevel = :multiple)
+    end
+
+    comm = MPI.COMM_WORLD
+    rank = MPI.Comm_rank(comm)
+
+    if CUDA.functional()
+        CUDA.device!(MPI.Comm_rank(comm) % length(CUDA.devices()))
+        CUDA.allowscalar(false)
+    end
+
+    FT = Float64
+    N = (4, 5)
+
+    # run on the GPU if possible
+    AT = CUDA.functional() && CUDA.has_cuda_gpu() ? CuArray : Array
+
+    if rank == 0
+        @info """Configuration:
+            precision        = $FT
+            polynomial order = $N
+            array type       = $AT
+        """
+    end
+
+    # visualize solution of advected Gaussian
+    K = 2
+    L = 2
+    vtkdir = "vtk_semdg_advection_2d$(K)x$(K)_L$(L)"
+    if rank == 0
+        @info """Starting Gaussian advection with:
+            ($K, $K) coarse grid
+            $L refinement level
+        """
+    end
+
+    run(gaussian, FT, AT, N, K, L; outputvtk = true, vtkdir, comm)
+    rank == 0 && @info "Finished, vtk output written to $vtkdir"
+
+    # run convergence study using a simple sine field
+    rank == 0 && @info "Starting convergence study"
+    numlevels = 5
+    err = zeros(FT, numlevels)
+    for l = 1:numlevels
+        L = l - 1
+        K = 4
+        totalcells = (K * 2^L, K * 2^L)
+        err[l] = run(sineproduct, FT, AT, N, K, L; comm)
+        if rank == 0
+            @info @sprintf(
+                "Level %d, cells = (%2d, %2d), error = %.16e",
+                l,
+                totalcells...,
+                err[l]
+            )
+        end
+    end
+    rates = log2.(err[1:numlevels-1] ./ err[2:numlevels])
+    if rank == 0
+        @info "Convergence rates:\n" * join(
+            ["rate for levels $l → $(l + 1) = $(rates[l])" for l = 1:(numlevels-1)],
+            "\n",
+        )
+    end
+
+end

--- a/examples/advection/semdg_advection_2d.jl
+++ b/examples/advection/semdg_advection_2d.jl
@@ -384,7 +384,7 @@ end
 
 let
     if !MPI.Initialized()
-        MPI.Init(; threadlevel = :multiple)
+        MPI.Init()
     end
 
     comm = MPI.COMM_WORLD

--- a/examples/advection/semdg_advection_2d.jl
+++ b/examples/advection/semdg_advection_2d.jl
@@ -232,7 +232,7 @@ function rhs!(dq, q, grid, invwJ, DT, cm)
     n, wsJ = components(surfacemetrics(grid)[3])
     fm = facemaps(grid)
 
-    Raven.start!(q, cm)
+    start!(q, cm)
 
     C = max(512 ÷ prod(size(cell)), 1)
     rhs_volume_kernel!(backend, (size(cell)..., C))(
@@ -248,7 +248,7 @@ function rhs!(dq, q, grid, invwJ, DT, cm)
         ndrange = size(dq),
     )
 
-    Raven.finish!(q, cm)
+    finish!(q, cm)
 
     J = maximum(size(cell))
     C = max(512 ÷ J, 1)
@@ -344,7 +344,7 @@ function run(
     # precompute derivative transpose
     DT = transpose.(derivatives_1d(cell))
 
-    cm = Raven.commmanager(eltype(q), comm, nodecommpattern(grid), 0)
+    cm = commmanager(eltype(q), comm, nodecommpattern(grid), 0)
 
     # initial output
     step = 0

--- a/ext/RavenCUDAExt.jl
+++ b/ext/RavenCUDAExt.jl
@@ -34,6 +34,10 @@ function Raven.adaptsparse(::Type{T}, S) where {T<:CuArray}
     return Adapt.adapt(T, Raven.GeneralSparseMatrixCSC(S))
 end
 
+Raven.Stream(::CUDABackend) = CuStream()
+Raven.synchronize(::CUDABackend, a) = synchronize(a)
+Raven.stream!(f::Function, ::CUDABackend, stream::CuStream) = stream!(f, stream)
+
 Adapt.adapt_storage(::CUDA.Adaptor, ::MPI.Comm) = nothing
 
 end # module RavenCUDAExt

--- a/src/Raven.jl
+++ b/src/Raven.jl
@@ -40,6 +40,7 @@ export adapt!
 include("orientation.jl")
 include("arrays.jl")
 include("sparsearrays.jl")
+include("streams.jl")
 include("eye.jl")
 include("facecode.jl")
 include("flatten.jl")

--- a/src/Raven.jl
+++ b/src/Raven.jl
@@ -22,7 +22,7 @@ export derivatives_1d, points_1d, weights_1d, tohalves_1d
 export referencecell, levels, trees, offset, numcells, facecodes
 export continuoustodiscontinuous, nodecommpattern
 export communicatingcells, noncommunicatingcells
-export facemaps
+export facemaps, boundarycodes
 export decode
 export commmanager, share!, start!, finish!, progress
 

--- a/src/Raven.jl
+++ b/src/Raven.jl
@@ -24,6 +24,7 @@ export continuoustodiscontinuous, nodecommpattern
 export communicatingcells, noncommunicatingcells
 export facemaps
 export decode
+export commmanager, share!, start!, finish!, progress
 
 export volumemetrics, surfacemetrics
 

--- a/src/communication.jl
+++ b/src/communication.jl
@@ -118,13 +118,19 @@ end
 
 usetriplebuffer(::Type{Array}) = false
 
-function commmanager(T, comm, pattern, tag)
+function commmanager(T, pattern; kwargs...)
     AT = arraytype(pattern)
     triplebuffer = usetriplebuffer(AT)
-    commmanager(T, comm, pattern, tag, Val(triplebuffer))
+    commmanager(T, pattern, Val(triplebuffer); kwargs...)
 end
 
-function commmanager(T, comm, pattern, tag, ::Val{triplebuffer}) where {triplebuffer}
+function commmanager(
+    T,
+    pattern,
+    ::Val{triplebuffer};
+    comm = MPI.COMM_WORLD,
+    tag = 0,
+) where {triplebuffer}
     AT = arraytype(pattern)
 
     if tag < 0 || tag > 32767

--- a/src/communication.jl
+++ b/src/communication.jl
@@ -148,16 +148,6 @@ function commmanager(
     recvrequests = MPI.UnsafeMultiRequest(length(pattern.recvranks))
     sendrequests = MPI.UnsafeMultiRequest(length(pattern.sendranks))
 
-    if triplebuffer &&
-       (!isempty(recvrequests) || !isempty(sendrequests)) &&
-       MPI.Query_thread() < MPI.THREAD_MULTIPLE
-        throw(
-            ErrorException(
-                "CommManagerTripleBuffered calls MPI functions from multiple threads and thus MPI needs to be initialized with MPI.Init(; threadlevel = MPI.THREAD_MULTIPLE).",
-            ),
-        )
-    end
-
     if triplebuffer
         recvbufferhost = Array{T}(undef, recvsize)
         sendbufferhost = Array{T}(undef, sendsize)

--- a/src/gridmanager.jl
+++ b/src/gridmanager.jl
@@ -269,7 +269,7 @@ function materializedtoc(forest, ghost, nodes, quadrantcommpattern, comm)
 
     pattern = expand(quadrantcommpattern, prod(size(dtoc_owned)[1:end-1]))
 
-    cm = commmanager(eltype(dtoc_global), comm, pattern, 0)
+    cm = commmanager(eltype(dtoc_global), pattern; comm)
 
     share!(dtoc_global, cm)
 
@@ -377,7 +377,7 @@ function generate(warp::Function, gm::GridManager)
     points = warp.(coarsegrid_warp.(points))
 
     fillghosts!(points, fill(NaN, eltype(points)))
-    pcm = commmanager(eltype(points), comm(gm), nodecommpattern, 0)
+    pcm = commmanager(eltype(points), nodecommpattern; comm = comm(gm))
     share!(points, pcm)
 
     volumemetrics, surfacemetrics =

--- a/src/gridmanager.jl
+++ b/src/gridmanager.jl
@@ -35,8 +35,7 @@ function GridManager(
     fill_uniform = true,
 )
     if !MPI.Initialized()
-        threadlevel = usetriplebuffer(arraytype(referencecell)) ? :multiple : :serialized
-        MPI.Init(; threadlevel)
+        MPI.Init()
     end
 
     comm = MPI.Comm_dup(comm)

--- a/src/gridmanager.jl
+++ b/src/gridmanager.jl
@@ -318,7 +318,7 @@ function generate(warp::Function, gm::GridManager)
 
     ctod_degree3_local = materializectod(dtoc_degree3_local)
 
-    facemaps = materializefacemaps(
+    facemaps, quadranttoboundary = materializefacemaps(
         referencecell(gm),
         P4estTypes.lengthoflocalquadrants(forest(gm)),
         ctod_degree3_local,
@@ -353,6 +353,7 @@ function generate(warp::Function, gm::GridManager)
     quadranttotreeid = A(pin(A, quadranttotreeid))
     quadranttocoordinate = A(pin(A, quadranttocoordinate))
     quadranttofacecode = A(pin(A, quadranttofacecode))
+    quadranttoboundary = A(pin(A, quadranttoboundary))
     parentnodes = A(pin(A, parentnodes))
     nodecommpattern = Adapt.adapt(A, nodecommpattern)
     continuoustodiscontinuous = adaptsparse(A, continuoustodiscontinuous)
@@ -402,6 +403,7 @@ function generate(warp::Function, gm::GridManager)
         quadranttolevel,
         quadranttotreeid,
         quadranttofacecode,
+        quadranttoboundary,
         parentnodes,
         nodecommpattern,
         continuoustodiscontinuous,

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -8,7 +8,7 @@ floattype(grid::AbstractGrid) = floattype(typeof(grid))
 arraytype(grid::AbstractGrid) = arraytype(typeof(grid))
 celltype(grid::AbstractGrid) = celltype(typeof(grid))
 
-struct Grid{C<:AbstractCell,P,V,S,L,T,F,PN,N,CTOD,DTOC,CC,FM} <: AbstractGrid{C}
+struct Grid{C<:AbstractCell,P,V,S,L,T,F,B,PN,N,CTOD,DTOC,CC,FM} <: AbstractGrid{C}
     comm::MPI.Comm
     part::Int
     nparts::Int
@@ -21,6 +21,7 @@ struct Grid{C<:AbstractCell,P,V,S,L,T,F,PN,N,CTOD,DTOC,CC,FM} <: AbstractGrid{C}
     levels::L
     trees::T
     facecodes::F
+    boundarycodes::B
     parentnodes::PN
     nodecommpattern::N
     continuoustodiscontinuous::CTOD
@@ -50,6 +51,11 @@ facecodes(grid::Grid) = facecodes(grid, Val(false))
 facecodes(grid::Grid, ::Val{false}) = grid.facecodes
 facecodes(::Grid, ::Val{true}) =
     throw(error("Face codes are currently stored for local quadrants."))
+
+boundarycodes(grid::Grid) = boundarycodes(grid, Val(false))
+boundarycodes(grid::Grid, ::Val{false}) = grid.boundarycodes
+boundarycodes(::Grid, ::Val{true}) =
+    throw(error("Boundary codes are currently stored for local quadrants."))
 
 nodecommpattern(grid::Grid) = grid.nodecommpattern
 continuoustodiscontinuous(grid::Grid) = grid.continuoustodiscontinuous

--- a/src/lobattocells.jl
+++ b/src/lobattocells.jl
@@ -1203,7 +1203,7 @@ function materializemetrics(
         ndrange = size(points),
     )
 
-    fcm = commmanager(eltype(firstordermetrics), comm, nodecommpattern, 0)
+    fcm = commmanager(eltype(firstordermetrics), nodecommpattern; comm)
     share!(firstordermetrics, fcm)
 
     volumemetrics = (firstordermetrics, secondordermetrics)
@@ -1537,7 +1537,7 @@ function materializemetrics(
     # We need this to compute the normals and surface Jacobian on the
     # non-conforming faces.  Should we change the nonconforming surface
     # information to avoid this communication?
-    fcm = commmanager(eltype(firstordermetrics), comm, nodecommpattern, 0)
+    fcm = commmanager(eltype(firstordermetrics), nodecommpattern; comm)
     share!(firstordermetrics, fcm)
 
     volumemetrics = (firstordermetrics, secondordermetrics)

--- a/src/streams.jl
+++ b/src/streams.jl
@@ -1,0 +1,3 @@
+Stream(_) = nothing
+synchronize(backend, _) = KernelAbstractions.synchronize(backend)
+stream!(f::Function, _, _) = f()

--- a/test/gridnumbering.jl
+++ b/test/gridnumbering.jl
@@ -327,29 +327,28 @@
             pts = Adapt.adapt(Array, pts)
             fm = Adapt.adapt(Array, facemaps(grid))
 
-            @test isapprox(pts[fm.vmapM[1]], pts[fm.vmapP[1]])
-            @test isapprox(pts[fm.vmapM[2]], pts[fm.vmapP[2]])
+            @test isapprox(pts[fm.vmapM], pts[fm.vmapP])
+            @test isapprox(pts[fm.vmapM[fm.mapM]], pts[fm.vmapM[fm.mapP]])
 
-            @test isapprox(pts[fm.avmapM], pts[fm.avmapP])
-            @test isapprox(pts[fm.avmapM[fm.amapM]], pts[fm.avmapM[fm.amapP]])
-
-            for n in eachindex(fm.mapB, fm.vmapM)
-                # Test that faces in mapB are on the boundary
-                @test all(
-                    isapprox.(
-                        one(FT),
-                        map(x -> maximum(abs.(x)), pts[fm.vmapM[n][fm.mapB[n]]]),
-                    ),
-                )
-
-                # Test that faces not in mapB are not on the boundary
-                Nf = N^(ndims(cell) - 1)
-                mapBn = reshape(fm.mapB[n], (Nf, :))
-                vmapMn = reshape(fm.vmapM[n], (Nf, :))
-                boundaryfaces = fld1.(mapBn, Nf)[1, :]
-                nonboundaryfaces = setdiff(1:size(vmapMn, 2), boundaryfaces)
-                for f in nonboundaryfaces
-                    @test !all(isapprox.(one(FT), map(x -> maximum(abs.(x)), pts[vmapMn])))
+            bc = boundarycodes(grid)
+            vmapM = reshape(fm.vmapM, (N, 4, :))
+            for q = 1:numcells(grid)
+                for f = 1:4
+                    if bc[f, q] == 1
+                        @test all(
+                            isapprox.(
+                                one(FT),
+                                map(x -> maximum(abs.(x)), pts[vmapM[:, f, q]]),
+                            ),
+                        )
+                    else
+                        @test !all(
+                            isapprox.(
+                                one(FT),
+                                map(x -> maximum(abs.(x)), pts[vmapM[:, f, q]]),
+                            ),
+                        )
+                    end
                 end
             end
         end
@@ -514,30 +513,29 @@
 
             pts = Adapt.adapt(Array, pts)
             fm = Adapt.adapt(Array, facemaps(grid))
-            @test isapprox(pts[fm.vmapM[1]], pts[fm.vmapP[1]])
-            @test isapprox(pts[fm.vmapM[2]], pts[fm.vmapP[2]])
-            @test isapprox(pts[fm.vmapM[3]], pts[fm.vmapP[3]])
 
-            @test isapprox(pts[fm.avmapM], pts[fm.avmapP])
-            @test isapprox(pts[fm.avmapM[fm.amapM]], pts[fm.avmapM[fm.amapP]])
+            @test isapprox(pts[fm.vmapM], pts[fm.vmapP])
+            @test isapprox(pts[fm.vmapM[fm.mapM]], pts[fm.vmapM[fm.mapP]])
 
-            for n in eachindex(fm.mapB, fm.vmapM)
-                # Test that faces in mapB are on the boundary
-                @test all(
-                    isapprox.(
-                        one(FT),
-                        map(x -> maximum(abs.(x)), pts[fm.vmapM[n][fm.mapB[n]]]),
-                    ),
-                )
-
-                # Test that faces not in mapB are not on the boundary
-                Nf = N^(ndims(cell) - 1)
-                mapBn = reshape(fm.mapB[n], (Nf, :))
-                vmapMn = reshape(fm.vmapM[n], (Nf, :))
-                boundaryfaces = fld1.(mapBn, Nf)[1, :]
-                nonboundaryfaces = setdiff(1:size(vmapMn, 2), boundaryfaces)
-                for f in nonboundaryfaces
-                    @test !all(isapprox.(one(FT), map(x -> maximum(abs.(x)), pts[vmapMn])))
+            bc = boundarycodes(grid)
+            vmapM = reshape(fm.vmapM, (N, N, 6, :))
+            for q = 1:numcells(grid)
+                for f = 1:6
+                    if bc[f, q] == 1
+                        @test all(
+                            isapprox.(
+                                one(FT),
+                                map(x -> maximum(abs.(x)), pts[vmapM[:, :, f, q]]),
+                            ),
+                        )
+                    else
+                        @test !all(
+                            isapprox.(
+                                one(FT),
+                                map(x -> maximum(abs.(x)), pts[vmapM[:, :, f, q]]),
+                            ),
+                        )
+                    end
                 end
             end
         end

--- a/test/mpitest_n2_commgridarrays.jl
+++ b/test/mpitest_n2_commgridarrays.jl
@@ -18,7 +18,7 @@ function test(::Type{FT}, ::Type{AT}) where {FT,AT}
         grid = generate(gm)
 
         T = SVector{2,FT}
-        cm = Raven.commmanager(T, Raven.comm(grid), grid.nodecommpattern, 1)
+        cm = Raven.commmanager(T, nodecommpattern(grid); comm = Raven.comm(grid), tag = 1)
         A = GridArray{T}(undef, grid)
 
         nan = convert(FT, NaN)

--- a/test/mpitest_n2_commgridarrays.jl
+++ b/test/mpitest_n2_commgridarrays.jl
@@ -6,7 +6,7 @@ using Raven
 using Raven.StaticArrays
 using Raven.Adapt
 
-MPI.Init(; threadlevel = MPI.THREAD_MULTIPLE)
+MPI.Init()
 
 function test(::Type{FT}, ::Type{AT}) where {FT,AT}
     @testset "Communicate GridArray ($AT, $FT)" begin

--- a/test/mpitest_n2_gridnumbering.jl
+++ b/test/mpitest_n2_gridnumbering.jl
@@ -7,7 +7,7 @@ using Raven.StaticArrays
 using Raven.P4estTypes
 using Raven.SparseArrays
 
-MPI.Init(; threadlevel = MPI.THREAD_MULTIPLE)
+MPI.Init()
 
 let
     FT = Float64

--- a/test/mpitest_n2_gridnumbering.jl
+++ b/test/mpitest_n2_gridnumbering.jl
@@ -71,35 +71,28 @@ let
         @test noncommcells == setdiff(0x1:numcells(grid), commcells)
 
         fm = facemaps(grid)
-        @test isapprox(pts[fm.vmapM[1]], pts[fm.vmapP[1]])
-        @test isapprox(pts[fm.vmapM[2]], pts[fm.vmapP[2]])
-
         @test isapprox(
-            pts[fm.avmapM[:, 1:numcells(grid)]],
-            pts[fm.avmapP[:, 1:numcells(grid)]],
+            pts[fm.vmapM[:, 1:numcells(grid)]],
+            pts[fm.vmapP[:, 1:numcells(grid)]],
         )
         @test isapprox(
-            pts[fm.avmapM[fm.amapM[:, 1:numcells(grid)]]],
-            pts[fm.avmapM[fm.amapP[:, 1:numcells(grid)]]],
+            pts[fm.vmapM[fm.mapM[:, 1:numcells(grid)]]],
+            pts[fm.vmapM[fm.mapP[:, 1:numcells(grid)]]],
         )
 
-        for n in eachindex(fm.mapB, fm.vmapM)
-            # Test that faces in mapB are on the boundary
-            @test all(
-                isapprox.(
-                    one(FT),
-                    map(x -> maximum(abs.(x)), pts[fm.vmapM[n][fm.mapB[n]]]),
-                ),
-            )
-
-            # Test that faces not in mapB are not on the boundary
-            Nf = N^(ndims(cell) - 1)
-            mapBn = reshape(fm.mapB[n], (Nf, :))
-            vmapMn = reshape(fm.vmapM[n], (Nf, :))
-            boundaryfaces = fld1.(mapBn, Nf)[1, :]
-            nonboundaryfaces = setdiff(1:size(vmapMn, 2), boundaryfaces)
-            for f in nonboundaryfaces
-                @test !all(isapprox.(one(FT), map(x -> maximum(abs.(x)), pts[vmapMn])))
+        bc = boundarycodes(grid)
+        vmapM = reshape(fm.vmapM, (N, 4, :))
+        for q in numcells(grid)
+            for f = 1:4
+                if bc[f, q] == 1
+                    @test all(
+                        isapprox.(one(FT), map(x -> maximum(abs.(x)), pts[vmapM[:, f, q]])),
+                    )
+                else
+                    @test !all(
+                        isapprox.(one(FT), map(x -> maximum(abs.(x)), pts[vmapM[:, f, q]])),
+                    )
+                end
             end
         end
 
@@ -303,43 +296,34 @@ let
         @test noncommcells == setdiff(0x1:numcells(grid), commcells)
 
         fm = facemaps(grid)
-        @test isapprox(pts[fm.vmapM[1]], pts[fm.vmapP[1]])
-        @test isapprox(pts[fm.vmapM[2]], pts[fm.vmapP[2]])
-        @test isapprox(pts[fm.vmapM[3]], pts[fm.vmapP[3]])
-
         @test isapprox(
-            pts[fm.avmapM[:, 1:numcells(grid)]],
-            pts[fm.avmapP[:, 1:numcells(grid)]],
+            pts[fm.vmapM[:, 1:numcells(grid)]],
+            pts[fm.vmapP[:, 1:numcells(grid)]],
         )
         @test isapprox(
-            pts[fm.avmapM[fm.amapM[:, 1:numcells(grid)]]],
-            pts[fm.avmapM[fm.amapP[:, 1:numcells(grid)]]],
+            pts[fm.vmapM[fm.mapM[:, 1:numcells(grid)]]],
+            pts[fm.vmapM[fm.mapP[:, 1:numcells(grid)]]],
         )
 
-        @test all(
-            isapprox.(one(FT), map(x -> maximum(abs.(x)), pts[fm.vmapM[2][fm.mapB[2]]])),
-        )
-        @test all(
-            isapprox.(one(FT), map(x -> maximum(abs.(x)), pts[fm.vmapM[3][fm.mapB[3]]])),
-        )
-
-        for n in eachindex(fm.mapB, fm.vmapM)
-            # Test that faces in mapB are on the boundary
-            @test all(
-                isapprox.(
-                    one(FT),
-                    map(x -> maximum(abs.(x)), pts[fm.vmapM[n][fm.mapB[n]]]),
-                ),
-            )
-
-            # Test that faces not in mapB are not on the boundary
-            Nf = N^(ndims(cell) - 1)
-            mapBn = reshape(fm.mapB[n], (Nf, :))
-            vmapMn = reshape(fm.vmapM[n], (Nf, :))
-            boundaryfaces = fld1.(mapBn, Nf)[1, :]
-            nonboundaryfaces = setdiff(1:size(vmapMn, 2), boundaryfaces)
-            for f in nonboundaryfaces
-                @test !all(isapprox.(one(FT), map(x -> maximum(abs.(x)), pts[vmapMn])))
+        bc = boundarycodes(grid)
+        vmapM = reshape(fm.vmapM, (N, N, 6, :))
+        for q in numcells(grid)
+            for f = 1:6
+                if bc[f, q] == 1
+                    @test all(
+                        isapprox.(
+                            one(FT),
+                            map(x -> maximum(abs.(x)), pts[vmapM[:, :, f, q]]),
+                        ),
+                    )
+                else
+                    @test !all(
+                        isapprox.(
+                            one(FT),
+                            map(x -> maximum(abs.(x)), pts[vmapM[:, :, f, q]]),
+                        ),
+                    )
+                end
             end
         end
 

--- a/test/mpitest_n3_communication.jl
+++ b/test/mpitest_n3_communication.jl
@@ -4,7 +4,7 @@ using MPI
 using Test
 using Raven
 
-MPI.Init(; threadlevel = MPI.THREAD_MULTIPLE)
+MPI.Init()
 
 let
     mpisize = MPI.Comm_size(MPI.COMM_WORLD)

--- a/test/mpitest_n3_communication.jl
+++ b/test/mpitest_n3_communication.jl
@@ -89,8 +89,8 @@ let
         sendrankindices,
     )
 
-    cm1 = Raven.commmanager(eltype(data1), MPI.COMM_WORLD, pattern, 1, Val(false))
-    cm2 = Raven.commmanager(eltype(data2), MPI.COMM_WORLD, pattern, 2, Val(true))
+    cm1 = Raven.commmanager(eltype(data1), pattern, Val(false); tag = 1)
+    cm2 = Raven.commmanager(eltype(data2), pattern, Val(true); tag = 2)
 
     Raven.start!(data2, cm2)
 
@@ -114,8 +114,8 @@ let
             sendrankindices,
         )
 
-        cm3 = Raven.commmanager(eltype(data3), MPI.COMM_WORLD, pattern, 1)
-        cm4 = Raven.commmanager(eltype(data4), MPI.COMM_WORLD, pattern, 2, Val(true))
+        cm3 = Raven.commmanager(eltype(data3), pattern; tag = 1)
+        cm4 = Raven.commmanager(eltype(data4), pattern, Val(true); tag = 2)
 
         Raven.start!(data4, cm4)
 

--- a/test/mpitest_n3_gridarrays.jl
+++ b/test/mpitest_n3_gridarrays.jl
@@ -7,7 +7,7 @@ using Raven.StaticArrays
 using LinearAlgebra
 using Raven.Adapt
 
-MPI.Init(; threadlevel = MPI.THREAD_MULTIPLE)
+MPI.Init()
 
 struct Stiffness <: FieldArray{Tuple{2,2},Float64,2}
     xx::Float64

--- a/test/mpitest_n3_gridnumbering.jl
+++ b/test/mpitest_n3_gridnumbering.jl
@@ -6,7 +6,7 @@ using Raven
 using Raven.StaticArrays
 using Raven.P4estTypes
 
-MPI.Init(; threadlevel = MPI.THREAD_MULTIPLE)
+MPI.Init()
 
 function isisomorphic(a, b)
     f = Dict{eltype(a),eltype(b)}()


### PR DESCRIPTION
- Add advection example
- Export the communication manager and its functions
- Cleanup communication manager interface
- Add streams abstraction
- Use streams for triple buffer communication
- Use default MPI initialization
- Use nonblocking syncs in advection example
- Pick one surface dof layout
- Remove Julia 1.6 from GitHub CI
