### PR TITLE
Remove `SHermitianCompact` from kernels

### DIFF
--- a/src/lobattocells.jl
+++ b/src/lobattocells.jl
@@ -1300,11 +1300,14 @@ end
             dXds[] += Ds[j, n] * X[i, n, p]
         end
 
-        G = SHermitianCompact(
-            SVector(dot(dXdr[], dXdr[]), dot(dXdr[], dXds[]), dot(dXds[], dXds[])),
+        G = SMatrix{2,2,eltype(Dr),4}(
+            dot(dXdr[], dXdr[]),
+            dot(dXdr[], dXds[]),
+            dot(dXdr[], dXds[]),
+            dot(dXds[], dXds[]),
         )
 
-        invG = SHermitianCompact(inv(G))
+        invG = inv(G)
 
         dRdX = invG * [dXdr[] dXds[]]'
 
@@ -1357,7 +1360,9 @@ end
 
         # invwJ = inv(wJ)
 
-        wJinvG = SHermitianCompact(SVector(wJ * (drdx)^2, -zero(dx), wJ * (dsdy)^2))
+        wJinvG = SMatrix{2,2,typeof(dx),4}(
+            SVector(wJ * (drdx)^2, -zero(dx), -zero(dx), wJ * (dsdy)^2),
+        )
 
         firstordermetrics[i, j, q] = (; dRdX, wJ)
         secondordermetrics[i, j, q] = (; wJinvG, wJ)
@@ -1726,15 +1731,16 @@ end
 
             # invwJ = inv(wJ)
 
-            wJinvG = SHermitianCompact(
-                SVector(
-                    wJ * (drdx)^2,
-                    -zero(dx),
-                    -zero(dx),
-                    wJ * (dsdy)^2,
-                    -zero(dx),
-                    wJ * (dtdz)^2,
-                ),
+            wJinvG = SMatrix{3,3,typeof(dx),9}(
+                wJ * (drdx)^2,
+                -zero(dx),
+                -zero(dx),
+                -zero(dx),
+                wJ * (dsdy)^2,
+                -zero(dx),
+                -zero(dx),
+                -zero(dx),
+                wJ * (dtdz)^2,
             )
 
             firstordermetrics[i, j, k, q] = (; dRdX, wJ)


### PR DESCRIPTION
Using `SHermitianCompact` was causing kernels not to compile in Julia
v1.10.0-beta2.  So, `SHermitianCompact` is only used as a storage
format for now.

Here [1] is the upstream issue.

[1]: https://github.com/JuliaGPU/CUDA.jl/issues/2069
