### PR TITLE
Fix mapP and vmapP for periodic elements

### DIFF
--- a/src/lobattocells.jl
+++ b/src/lobattocells.jl
@@ -1896,7 +1896,7 @@ function materializefacemaps(
                 for ii in neighborsrange
                     nq, pi = fldmod1(rows[ii], 4^ndims(cell))
                     nf = _indextoface(pi, degree3facelinearindices)
-                    if nq != q && nf != f
+                    if nq != q || nf != f
                         break
                     end
                 end

--- a/test/gridnumbering.jl
+++ b/test/gridnumbering.jl
@@ -355,6 +355,25 @@
     end
 
     let
+        cell = LobattoCell{Tuple{2,2,2}}()
+        cg = brick((1, 1, 1), (true, true, true))
+        gm = GridManager(cell, cg)
+        grid = generate(gm)
+        fm = facemaps(grid)
+        @test fm.vmapP ==
+              [2; 4; 6; 8; 1; 3; 5; 7; 3; 4; 7; 8; 1; 2; 5; 6; 5; 6; 7; 8; 1; 2; 3; 4;;]
+    end
+
+    let
+        cell = LobattoCell{Tuple{2,2}}()
+        cg = brick((1, 1), (true, true))
+        gm = GridManager(cell, cg)
+        grid = generate(gm)
+        fm = facemaps(grid)
+        @test fm.vmapP == [2; 4; 1; 3; 3; 4; 1; 2;;]
+    end
+
+    let
         FT = Float64
         AT = Array
 


### PR DESCRIPTION
This fixes the mappings when the grid has one element in the periodic
dimension.
